### PR TITLE
Fix for Windows environments.

### DIFF
--- a/src/dk/brics/tajs/util/PathAndURLUtils.java
+++ b/src/dk/brics/tajs/util/PathAndURLUtils.java
@@ -129,7 +129,7 @@ public class PathAndURLUtils {
      */
     public static Path getRelativeTo(Path from, Path to) {
         Path toAbs = to.toAbsolutePath();
-        toAbs = transformPath(from.getFileSystem(), toAbs);
+        toAbs = transformPath(from.getFileSystem(), toAbs).toAbsolutePath();
         return from.toAbsolutePath().normalize().relativize(toAbs).normalize();
     }
 


### PR DESCRIPTION
Make sure the comparison is between two absolute paths (i.e., starting with the hard drive name).

Hello.

I'm running this on Windows and I've encountered a problem. I did everything that was stated in the README file. Yet, when I execute the command `java -jar dist/tajs-all.jar test-resources/src/google/richards.js` (with this or any other test file, regardless of its location), I would always get the following error:
```
Exception in thread "main" java.lang.IllegalArgumentException: 'other' is different type of Path
        at java.base/sun.nio.fs.WindowsPath.relativize(WindowsPath.java:400)
        at java.base/sun.nio.fs.WindowsPath.relativize(WindowsPath.java:42)
        at dk.brics.tajs.util.PathAndURLUtils.getRelativeTo(Unknown Source)
        at dk.brics.tajs.util.PathAndURLUtils.getRelativeToWorkingDirectory(Unknown Source)
        at dk.brics.tajs.flowgraph.SourceLocation.toUserFriendlyString(Unknown Source)
        at dk.brics.tajs.flowgraph.SourceLocation.toString(Unknown Source)
        at dk.brics.tajs.js2flowgraph.FlowGraphBuilder.reportParseMessages(Unknown Source)
        at dk.brics.tajs.js2flowgraph.FlowGraphBuilder.makeAST(Unknown Source)
        at dk.brics.tajs.js2flowgraph.FlowGraphBuilder.transformCode(Unknown Source)
        at dk.brics.tajs.js2flowgraph.FlowGraphBuilder.transformStandAloneCode(Unknown Source)
        at dk.brics.tajs.Main.init(Unknown Source)
        at dk.brics.tajs.Main.init(Unknown Source)
        at dk.brics.tajs.Main.main(Unknown Source)
```

After some search and trying to understand what were the values of `other` for each value `from`, `to` and `toAbs` on the method `getRelativeTo` from class `PathAndURLUtils`, I noticed the `toAbs` was not an absolute path, whereas `from` was, after `toAbsolutePath` being called on it (at the return statement of the aforementioned `getRelativeTo` method).
So, `from` was in the form of `C:\Users\...`, but `toAbs` was in the form of `\Users\...`, each with type `ABSOLUTE` and `DIRECTORY_RELATIVE`, respectively. They were different, hence, the error thrown by the `relativize` method.

With my changes, `toAbs` is now an absolute path, making the types of each path the same. It now works on Windows. Without this change it did, though, work for Linux.

I didn't do any extensive testing, but the code was also tested in a Linux environment, before and after this change and the results seem to be the same.